### PR TITLE
Fix eval with babel-loader

### DIFF
--- a/benchmarks/Rendering.cs
+++ b/benchmarks/Rendering.cs
@@ -26,11 +26,87 @@ namespace test
             _mjmlServices = provider.GetRequiredService<IMjmlServices>();
         }
 
+        [Params(false, true)]
+        public bool OldScript;
+
         [Benchmark]
         public async Task SimpleRender()
         {
-            
             var result = await _mjmlServices.Render("<mjml><mj-body></mj-body></mjml>");
+        }
+        
+        [Benchmark]
+        public async Task ComplexRender()
+        {
+            var view = @"
+<mjml>
+  <mj-body>
+    <mj-section>
+      <mj-column width='30%'>
+        <mj-image align='left' alt='Logo' src='https://placeholder.com/wp-content/uploads/2018/10/placeholder.com-logo4.png' padding='15px' />
+      </mj-column>
+    </mj-section>
+    <mj-section>
+      <mj-column>
+        <mj-text font-size='20px' font-family='Open Sans' padding-left='15px' padding-bottom='0'>Your Notifications</mj-text>
+      </mj-column>
+    </mj-section>
+    <mj-wrapper background-color='white' padding='15px'>
+      <mj-section padding='0 0 10px 0'>
+        <mj-column>
+          <mj-text font-family='Open Sans' font-size='16px' padding-left='0'>Hello User</mj-text>
+          <mj-text font-family='Open Sans' font-size='14px' padding-left='0' padding-bottom='0'>We have some notifications from  for you.</mj-text>
+        </mj-column>
+      </mj-section>
+
+      <mj-section padding='10px 0 0 0'>
+        <mj-group>
+          <mj-column width='100%'>
+            <mj-text font-family='Open Sans' font-size='16px' font-weight='bold' padding='0px 10px 10px 0px'>subject1</mj-text>
+            <mj-text font-family='Open Sans' font-size='14px' padding='0px 0px 5px 0px'>Lorem ipsum dolor sit amet, consetetur sadipscing elitr</mj-text>
+
+          </mj-column>
+        </mj-group>
+      </mj-section>
+      <mj-section padding-top='6px'>
+        <mj-column>
+          <mj-button align='left' background-color='#175DA8' border-radius='4px' font-family='Open Sans' font-size='16px' padding='0px' href='https://confirm.notifo.com'>Got It!</mj-button>
+        </mj-column>
+      </mj-section>
+      <mj-section padding='0'>
+        <mj-column>
+          <mj-image src='' width='0' height='0' />
+
+          <mj-divider padding='5px' border-color='#ddd' border-width='1px' />
+        </mj-column>
+      </mj-section>
+
+      <mj-section padding='0'>
+        <mj-column>
+          <mj-text font-family='Open Sans' font-size='14px' padding-left='0'>Best regards,</mj-text>
+          <mj-text font-family='Open Sans' font-size='14px' padding-left='0'>Your  team.</mj-text>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+    <mj-section>
+      <mj-column>
+        <mj-social font-family='Open Sans' font-size='15px' icon-size='20px' mode='horizontal'>
+          <mj-social-element name='facebook' href='https://notifo.io/'>Facebook</mj-social-element>
+          <mj-social-element name='google' href='https://notifo.io/'>Google</mj-social-element>
+          <mj-social-element name='twitter' href='https://notifo.io/'>Twitter</mj-social-element>
+        </mj-social>
+      </mj-column>
+    </mj-section>
+    <mj-section padding-top='10px'>
+      <mj-column>
+        <mj-text font-family='Open Sans' font-size='12px' padding='4px' align='center'>Acme Corporation, Inc.</mj-text>
+        <mj-text font-family='Open Sans' font-size='12px' padding='4px' align='center'>New York City, United Stated</mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>";
+
+            var result = await _mjmlServices.Render(view);
         }
 
         [Benchmark]

--- a/mjml-aspnetcore/webpack.config.js
+++ b/mjml-aspnetcore/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const webpack = require('webpack');
 
 module.exports = {
+    devtool: 'none',
     stats: {
         modules: false
     },


### PR DESCRIPTION
Hi,

I had a look to the renderer.js file and I found the following issue: https://stackoverflow.com/questions/50358773/webpack-babel-loader-transpiles-code-with-eval

I think this causes NodeJS to parse the scripts with each run and really hurts performance. I have fixed it in the webpack config.

|                 Method | OldScript |        Mean |    Error |   StdDev |
|----------------------- |---------- |------------:|---------:|---------:|
|           SimpleRender |     False |    456.1 us |  8.86 us | 12.98 us |
|          ComplexRender |     False |  5,803.2 us | 53.73 us | 50.26 us |
| ComplexRenderWithError |     False |  3,699.5 us | 31.04 us | 25.92 us |
|           SimpleRender |      True |    571.0 us | 10.80 us | 10.10 us |
|          ComplexRender |      True | 10,372.4 us | 72.31 us | 56.45 us |
| ComplexRenderWithError |      True |  7,396.1 us | 64.00 us | 56.74 us |